### PR TITLE
Fixes issue #9 

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -93,7 +93,7 @@ func (t *TokensWrapper) CheckExpiry() bool {
 	return t.Expires.Before(time.Now())
 }
 
-func (z Zoho) checkForSavedTokens() error {
+func (z *Zoho) checkForSavedTokens() error {
 	t, err := z.LoadTokens()
 	if err != nil && err != ErrTokenExpired {
 		return err


### PR DESCRIPTION
This fixes an issue where the request for generating a token would work initially but then subsequent requests would have empty values in the AccessTokenResponse. 
This was causing empty refresh token during http request causing the request to return an empty response.