### PR TITLE
Err token expired clause

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -93,7 +93,7 @@ func (t *TokensWrapper) CheckExpiry() bool {
 	return t.Expires.Before(time.Now())
 }
 
-func (z Zoho) checkForSavedTokens() error {
+func (z *Zoho) checkForSavedTokens() error {
 	t, err := z.LoadTokens()
 	if err != nil && err != ErrTokenExpired {
 		return err

--- a/storage.go
+++ b/storage.go
@@ -95,7 +95,7 @@ func (t *TokensWrapper) CheckExpiry() bool {
 
 func (z *Zoho) checkForSavedTokens() error {
 	t, err := z.LoadTokens()
-	if err != nil && err != ErrTokenExpired {
+	if err != nil && err == ErrTokenExpired {
 		return err
 	}
 


### PR DESCRIPTION
Error seems clause seems to be skipped if err is indeed ErrTokenExpired type.

