### PR TITLE
Refresh token after expiration

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -3,7 +3,6 @@ package zoho
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -48,7 +47,7 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 	}
 	//If the tokenResponse is not valid it should not update local tokens
 	if tokenResponse.Error == "invalid_code" {
-		return errors.New("Invalid Code")
+		return ErrTokenInvalidCode
 	}
 
 	z.oauth.token.AccessToken = tokenResponse.AccessToken
@@ -114,7 +113,7 @@ func (z *Zoho) GenerateTokenRequest(clientID, clientSecret, code, redirectURI st
 
 	//If the tokenResponse is not valid it should not update local tokens
 	if tokenResponse.Error == "invalid_code" {
-		return errors.New("Invalid Code Error")
+		return ErrTokenInvalidCode
 	}
 
 	z.oauth.clientID = clientID

--- a/oauth2.go
+++ b/oauth2.go
@@ -70,10 +70,12 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 // to this function which will generate your access token and refresh tokens.
 func (z *Zoho) GenerateTokenRequest(clientID, clientSecret, code, redirectURI string) (err error) {
 	err = z.checkForSavedTokens()
+
+	z.oauth.clientID = clientID
+	z.oauth.clientSecret = clientSecret
+	z.oauth.redirectURI = redirectURI
+
 	if err == ErrTokenExpired {
-		z.oauth.clientID = clientID
-		z.oauth.clientSecret = clientSecret
-		z.oauth.redirectURI = redirectURI
 		return z.RefreshTokenRequest()
 	}
 

--- a/oauth2.go
+++ b/oauth2.go
@@ -69,11 +69,13 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 // and click the kebab icon beside your clienID, and click 'Self-Client'; then you can define you scopes and an expiry, then provide the generated authorization code
 // to this function which will generate your access token and refresh tokens.
 func (z *Zoho) GenerateTokenRequest(clientID, clientSecret, code, redirectURI string) (err error) {
+
+	z.oauth.clientID = clientID
+	z.oauth.clientSecret = clientSecret
+	z.oauth.redirectURI = redirectURI
+
 	err = z.checkForSavedTokens()
 	if err == ErrTokenExpired {
-		z.oauth.clientID = clientID
-		z.oauth.clientSecret = clientSecret
-		z.oauth.redirectURI = redirectURI
 		return z.RefreshTokenRequest()
 	}
 

--- a/oauth2.go
+++ b/oauth2.go
@@ -70,12 +70,10 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 // to this function which will generate your access token and refresh tokens.
 func (z *Zoho) GenerateTokenRequest(clientID, clientSecret, code, redirectURI string) (err error) {
 	err = z.checkForSavedTokens()
-
-	z.oauth.clientID = clientID
-	z.oauth.clientSecret = clientSecret
-	z.oauth.redirectURI = redirectURI
-
 	if err == ErrTokenExpired {
+		z.oauth.clientID = clientID
+		z.oauth.clientSecret = clientSecret
+		z.oauth.redirectURI = redirectURI
 		return z.RefreshTokenRequest()
 	}
 

--- a/storage.go
+++ b/storage.go
@@ -4,12 +4,11 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
 	"net/http"
 	"os"
 	"time"
-
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 // TokenLoaderSaver is an interface that can be implemented when using a system that does
@@ -68,7 +67,7 @@ func (z Zoho) LoadTokens() (AccessTokenResponse, error) {
 	}
 
 	if v.CheckExpiry() {
-		return AccessTokenResponse{}, ErrTokenExpired
+		return v.Tokens, ErrTokenExpired
 	}
 
 	return v.Tokens, nil
@@ -95,12 +94,13 @@ func (t *TokensWrapper) CheckExpiry() bool {
 
 func (z *Zoho) checkForSavedTokens() error {
 	t, err := z.LoadTokens()
+	z.oauth.token = t
+
 	if err != nil && err == ErrTokenExpired {
 		return err
 	}
 
 	if (t != AccessTokenResponse{}) && err != ErrTokenExpired {
-		z.oauth.token = t
 		return nil
 	}
 	return fmt.Errorf("No saved tokens")

--- a/storage.go
+++ b/storage.go
@@ -76,6 +76,9 @@ func (z Zoho) LoadTokens() (AccessTokenResponse, error) {
 // ErrTokenExpired should be returned when the token is expired but still exists in persistence
 var ErrTokenExpired = errors.New("zoho: oAuth2 token already expired")
 
+// ErrTokenInvalidCode is turned when the autorization code in a request is invalid
+var ErrTokenInvalidCode = errors.New("zoho: authorization-code is invalid ")
+
 // TokensWrapper should be used to provide the time.Time corresponding to the expiry of an access token
 type TokensWrapper struct {
 	Tokens  AccessTokenResponse


### PR DESCRIPTION
In issue #9 I was consistently not able to get fresh tokens after my initial token expired. I noticed that the token was empty after saving the token even if the response from zoho was an invalid code. I wanted to use the refresh token method if the token had expired so this PR tries to do this. 
The PR also stops an invalid code response from zoho to persist a non-usable token to the filesystem. 
