### PR TITLE
Set proper expiration time

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -53,7 +53,6 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 	z.oauth.token.AccessToken = tokenResponse.AccessToken
 	z.oauth.token.APIDomain = tokenResponse.APIDomain
 	z.oauth.token.ExpiresIn = tokenResponse.ExpiresIn
-	z.oauth.token.ExpiresInSeconds = tokenResponse.ExpiresInSeconds
 	z.oauth.token.TokenType = tokenResponse.TokenType
 
 	err = z.SaveTokens(z.oauth.token)
@@ -233,13 +232,12 @@ func (z *Zoho) AuthorizationCodeRequest(clientID, clientSecret string, scopes []
 
 // AccessTokenResponse is the data returned when generating AccessTokens, or Refreshing the token
 type AccessTokenResponse struct {
-	AccessToken      string `json:"access_token,omitempty"`
-	RefreshToken     string `json:"refresh_token,omitempty"`
-	ExpiresInSeconds int    `json:"expires_in_sec,omitempty"`
-	ExpiresIn        int    `json:"expires_in,omitempty"`
-	APIDomain        string `json:"api_domain,omitempty"`
-	TokenType        string `json:"token_type,omitempty"`
-	Error            string `json:"error,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	APIDomain    string `json:"api_domain,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	Error        string `json:"error,omitempty"`
 }
 
 const (

--- a/storage.go
+++ b/storage.go
@@ -87,7 +87,7 @@ type TokensWrapper struct {
 
 // SetExpiry sets the TokenWrappers expiry time to now + seconds until expiry
 func (t *TokensWrapper) SetExpiry() {
-	t.Expires = time.Now().Add(time.Duration(t.Tokens.ExpiresInSeconds) * time.Second)
+	t.Expires = time.Now().Add(time.Duration(t.Tokens.ExpiresIn) * time.Second)
 }
 
 // CheckExpiry if the token expired before this instant


### PR DESCRIPTION
I had this weird issue where I was constantly requesting refresh tokens and constantly getting `{error:'invalid_code'}` responses.
The successful response from generating token did not have `expires_in_seconds` value

![image](https://user-images.githubusercontent.com/1777648/71556335-62dbda80-2a05-11ea-9caa-feae989f5b91.png)
