### PR TITLE
Export crm.crmModule

### DIFF
--- a/crm/blueprints.go
+++ b/crm/blueprints.go
@@ -7,7 +7,7 @@ import (
 
 // GetBlueprint retrieves a blueprint record specified by the ID parameter from the module specified
 // https://www.zoho.com/crm/help/api/v2/#blueprint-api
-func (c *API) GetBlueprint(module crmModule, id string) (data BlueprintResponse, err error) {
+func (c *API) GetBlueprint(module Module, id string) (data BlueprintResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "blueprints",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/actions/blueprint", c.ZohoTLD, module, id),
@@ -70,7 +70,7 @@ type BlueprintResponse struct {
 
 // UpdateBlueprint updates the blueprint specified by ID in the specified module
 // https://www.zoho.com/crm/help/api/v2/#update-blueprint
-func (c *API) UpdateBlueprint(request UpdateBlueprintData, module crmModule, id string) (data UpdateBlueprintResponse, err error) {
+func (c *API) UpdateBlueprint(request UpdateBlueprintData, module Module, id string) (data UpdateBlueprintResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "blueprints",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/actions/blueprint", c.ZohoTLD, module, id),

--- a/crm/crm.go
+++ b/crm/crm.go
@@ -6,29 +6,29 @@ import (
 	"time"
 )
 
-type crmModule string
+type Module string
 
 // Proper names for CRM modules
 const (
-	AccountsModule       crmModule = "Accounts"
-	CallsModule          crmModule = "Calls"
-	CampaignsModule      crmModule = "Campaigns"
-	CasesModule          crmModule = "Cases"
-	ContactsModule       crmModule = "Contacts"
-	CustomModule         crmModule = "Custom"
-	DealsModule          crmModule = "Deals"
-	EventsModule         crmModule = "Events"
-	InvoicesModule       crmModule = "Invoices"
-	LeadsModule          crmModule = "Leads"
-	PotentialsModule     crmModule = "Potentials"
-	PriceBooksModule     crmModule = "PriceBooks"
-	ProductsModule       crmModule = "Products"
-	PurchaseOrdersModule crmModule = "PurchaseOrders"
-	QuotesModule         crmModule = "Quotes"
-	SalesOrdersModule    crmModule = "SalesOrders"
-	SolutionsModule      crmModule = "Solutions"
-	TasksModule          crmModule = "Tasks"
-	VendorsModule        crmModule = "Vendors"
+	AccountsModule       Module = "Accounts"
+	CallsModule          Module = "Calls"
+	CampaignsModule      Module = "Campaigns"
+	CasesModule          Module = "Cases"
+	ContactsModule       Module = "Contacts"
+	CustomModule         Module = "Custom"
+	DealsModule          Module = "Deals"
+	EventsModule         Module = "Events"
+	InvoicesModule       Module = "Invoices"
+	LeadsModule          Module = "Leads"
+	PotentialsModule     Module = "Potentials"
+	PriceBooksModule     Module = "PriceBooks"
+	ProductsModule       Module = "Products"
+	PurchaseOrdersModule Module = "PurchaseOrders"
+	QuotesModule         Module = "Quotes"
+	SalesOrdersModule    Module = "SalesOrders"
+	SolutionsModule      Module = "Solutions"
+	TasksModule          Module = "Tasks"
+	VendorsModule        Module = "Vendors"
 )
 
 // API is used for interacting with the Zoho CRM API

--- a/crm/notes.go
+++ b/crm/notes.go
@@ -39,7 +39,7 @@ func (c *API) GetNotes(params map[string]zoho.Parameter) (data NotesResponse, er
 
 // GetNote returns the note specified by ID and module
 // https://www.zoho.com/crm/help/api/v2/#get-spec-notes-data
-func (c *API) GetNote(module crmModule, id string) (data NotesResponse, err error) {
+func (c *API) GetNote(module Module, id string) (data NotesResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "notes",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/Notes", c.ZohoTLD, module, id),
@@ -150,7 +150,7 @@ type CreateNoteResponse struct {
 
 // CreateRecordNote will create a note on the specified record of the specified module
 // https://www.zoho.com/crm/help/api/v2/#create-spec-notes
-func (c *API) CreateRecordNote(request CreateRecordNoteData, module crmModule, recordID string) (data CreateRecordNoteResponse, err error) {
+func (c *API) CreateRecordNote(request CreateRecordNoteData, module Module, recordID string) (data CreateRecordNoteResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "notes",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/Notes", c.ZohoTLD, module, recordID),
@@ -184,7 +184,7 @@ type CreateRecordNoteData struct {
 
 // UpdateNote will update the note data of the specified note on the specified record of the module
 // https://www.zoho.com/crm/help/api/v2/#update-notes
-func (c *API) UpdateNote(request UpdateNoteData, module crmModule, recordID, noteID string) (data UpdateNoteResponse, err error) {
+func (c *API) UpdateNote(request UpdateNoteData, module Module, recordID, noteID string) (data UpdateNoteResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "notes",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/Notes/%s", c.ZohoTLD, module, recordID, noteID),
@@ -213,7 +213,7 @@ type UpdateNoteData = CreateRecordNoteData
 
 // DeleteNote will delete the specified note on the specified record from the module
 // https://www.zoho.com/crm/help/api/v2/#delete-notes
-func (c *API) DeleteNote(module crmModule, recordID, noteID string) (data DeleteNoteResponse, err error) {
+func (c *API) DeleteNote(module Module, recordID, noteID string) (data DeleteNoteResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "notes",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s/Notes/%s", c.ZohoTLD, module, recordID, noteID),

--- a/crm/records.go
+++ b/crm/records.go
@@ -8,7 +8,7 @@ import (
 
 // ListRecords will return a list of the records provided in the request field, and specified by the module
 // https://www.zoho.com/crm/help/api/v2/#record-api
-func (c *API) ListRecords(request interface{}, module crmModule, params map[string]zoho.Parameter) (data interface{}, err error) {
+func (c *API) ListRecords(request interface{}, module Module, params map[string]zoho.Parameter) (data interface{}, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s", c.ZohoTLD, module),
@@ -44,7 +44,7 @@ func (c *API) ListRecords(request interface{}, module crmModule, params map[stri
 
 // InsertRecords will add records in request to the specified module
 // https://www.zoho.com/crm/help/api/v2/#ra-insert-records
-func (c *API) InsertRecords(request InsertRecordsData, module crmModule) (data InsertRecordsResponse, err error) {
+func (c *API) InsertRecords(request InsertRecordsData, module Module) (data InsertRecordsResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s", c.ZohoTLD, module),
@@ -116,7 +116,7 @@ type InsertRecordsResponse struct {
 //        crm.Account
 //        CustomField string `json:"Custom_Field"`
 //     }
-func (c *API) UpdateRecords(request UpdateRecordsData, module crmModule) (data UpdateRecordsResponse, err error) {
+func (c *API) UpdateRecords(request UpdateRecordsData, module Module) (data UpdateRecordsResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s", c.ZohoTLD, module),
@@ -156,7 +156,7 @@ type UpdateRecordsResponse struct {
 //        crm.Account
 //        CustomField string `json:"Custom_Field"`
 //     }
-func (c *API) UpsertRecords(request UpsertRecordsData, module crmModule, duplicateFieldsCheck []string) (data UpsertRecordsResponse, err error) {
+func (c *API) UpsertRecords(request UpsertRecordsData, module Module, duplicateFieldsCheck []string) (data UpsertRecordsResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/upsert", c.ZohoTLD, module),
@@ -224,7 +224,7 @@ type UpsertRecordsResponse struct {
 
 // DeleteRecords will delete the records in the ids in the specified module
 // https://www.zoho.com/crm/help/api/v2/#delete-bulk-records
-func (c *API) DeleteRecords(module crmModule, ids []string) (data DeleteRecordsResponse, err error) {
+func (c *API) DeleteRecords(module Module, ids []string) (data DeleteRecordsResponse, err error) {
 	if len(ids) == 0 {
 		return DeleteRecordsResponse{}, fmt.Errorf("Failed to delete records, must provide at least 1 ID")
 	}
@@ -274,7 +274,7 @@ type DeleteRecordsResponse struct {
 
 // ListDeletedRecords will return a list of all records that have been deleted in the specified module. The records can be filtered by the kind parameter.
 // https://www.zoho.com/crm/help/api/v2/#ra-deleted-records
-func (c *API) ListDeletedRecords(module crmModule, kind DeletedRecordsType, params map[string]zoho.Parameter) (data ListDeletedRecordsResponse, err error) {
+func (c *API) ListDeletedRecords(module Module, kind DeletedRecordsType, params map[string]zoho.Parameter) (data ListDeletedRecordsResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/deleted", c.ZohoTLD, module),
@@ -337,7 +337,7 @@ type ListDeletedRecordsResponse struct {
 // SearchRecords is used for searching records in the specified module using the parameters.
 // Parameters are 'criteria', 'email', 'phone', and 'word'
 // https://www.zoho.com/crm/help/api/v2/#ra-search-records
-func (c *API) SearchRecords(response interface{}, module crmModule, params map[string]zoho.Parameter) (data interface{}, err error) {
+func (c *API) SearchRecords(response interface{}, module Module, params map[string]zoho.Parameter) (data interface{}, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/search", c.ZohoTLD, module),
@@ -371,7 +371,7 @@ func (c *API) SearchRecords(response interface{}, module crmModule, params map[s
 
 // GetRecord will retrieve the specified record by id in the specified module.
 // https://www.zoho.com/crm/help/api/v2/#single-records
-func (c *API) GetRecord(request interface{}, module crmModule, ID string) (data interface{}, err error) {
+func (c *API) GetRecord(request interface{}, module Module, ID string) (data interface{}, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s", c.ZohoTLD, module, ID),
@@ -393,7 +393,7 @@ func (c *API) GetRecord(request interface{}, module crmModule, ID string) (data 
 
 // InsertRecord will insert the specifed record in the module
 // https://www.zoho.com/crm/help/api/v2/#create-specify-records
-func (c *API) InsertRecord(request InsertRecordData, module crmModule) (data InsertRecordResponse, err error) {
+func (c *API) InsertRecord(request InsertRecordData, module Module) (data InsertRecordResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s", c.ZohoTLD, module),
@@ -422,7 +422,7 @@ type InsertRecordResponse = InsertRecordsResponse
 
 // UpdateRecord will update the record specified by ID in the specified module
 // https://www.zoho.com/crm/help/api/v2/#update-specify-records
-func (c *API) UpdateRecord(request UpdateRecordData, module crmModule, ID string) (data UpdateRecordResponse, err error) {
+func (c *API) UpdateRecord(request UpdateRecordData, module Module, ID string) (data UpdateRecordResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s", c.ZohoTLD, module, ID),
@@ -451,7 +451,7 @@ type UpdateRecordResponse = UpdateRecordsResponse
 
 // DeleteRecord will delete the record specified by the id in the specified module
 // https://www.zoho.com/crm/help/api/v2/#delete-specify-records
-func (c *API) DeleteRecord(module crmModule, ID string) (data DeleteRecordResponse, err error) {
+func (c *API) DeleteRecord(module Module, ID string) (data DeleteRecordResponse, err error) {
 	endpoint := zoho.Endpoint{
 		Name:         "records",
 		URL:          fmt.Sprintf("https://www.zohoapis.%s/crm/v2/%s/%s", c.ZohoTLD, module, ID),


### PR DESCRIPTION
Hi, thanks for your work.

I'm using the crm module, and I would like to define an interface for some of `crm.API`'s methods, e.g.:

```
type x interface {
	InsertRecords(request crm.InsertRecordsData, module crm.crmModule) (data crm.InsertRecordsResponse, err error)
}

var _ x = &crm.API{}
```

However, `crm.crmModule` is not exported, so it's not possible (as far as I know) to define such an interface as a package user. And therefore, dependency injection is impossible, and testing becomes more complicated than needed.

Hence, my PR, in which `crm.CRMModule` gets exported. Sidenote: I think it's better to name it `crm.Module` to avoid the [stutter](https://blog.golang.org/package-names), but I didn't want to make a too disruptive change. Thanks!