### PR TITLE
Add "Invalid Client Secret" Error handling to oauth2 authorization functions

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
 )
 
 func (z *Zoho) SetRefreshToken(refreshToken string) {
@@ -62,6 +61,11 @@ func (z *Zoho) RefreshTokenRequest() (err error) {
 	//If the tokenResponse is not valid it should not update local tokens
 	if tokenResponse.Error == "invalid_code" {
 		return ErrTokenInvalidCode
+	}
+
+	//If the tokenResponse is not obtained from proper client secret it should not update local tokens
+	if tokenResponse.Error == "invalid_client_secret" {
+		return ErrClientSecretInvalidCode
 	}
 
 	z.oauth.token.AccessToken = tokenResponse.AccessToken
@@ -129,6 +133,11 @@ func (z *Zoho) GenerateTokenRequest(clientID, clientSecret, code, redirectURI st
 	//If the tokenResponse is not valid it should not update local tokens
 	if tokenResponse.Error == "invalid_code" {
 		return ErrTokenInvalidCode
+	}
+
+	//If the tokenResponse is not obtained from proper client secret it should not update local tokens
+	if tokenResponse.Error == "invalid_client_secret" {
+		return ErrClientSecretInvalidCode
 	}
 
 	z.oauth.clientID = clientID
@@ -270,10 +279,10 @@ type ScopeString string
 func BuildScope(service Service, scope Scope, method Method, operation Operation) ScopeString {
 	built := fmt.Sprintf("%s.%s", service, scope)
 	if method != "" {
-	    built += fmt.Sprintf(".%s", method)
+		built += fmt.Sprintf(".%s", method)
 	}
 	if operation != "" {
-	    built += fmt.Sprintf(".%s", operation)
+		built += fmt.Sprintf(".%s", operation)
 	}
 	return ScopeString(built)
 }

--- a/storage.go
+++ b/storage.go
@@ -4,11 +4,12 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 	"net/http"
 	"os"
 	"time"
+
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
 )
 
 // TokenLoaderSaver is an interface that can be implemented when using a system that does
@@ -78,6 +79,9 @@ var ErrTokenExpired = errors.New("zoho: oAuth2 token already expired")
 
 // ErrTokenInvalidCode is turned when the autorization code in a request is invalid
 var ErrTokenInvalidCode = errors.New("zoho: authorization-code is invalid ")
+
+// ErrClientSecretInvalidCode is turned when the client secret used is invalid
+var ErrClientSecretInvalidCode = errors.New("zoho: client secret used in authorization is invalid")
 
 // TokenWrapper should be used to provide the time.Time corresponding to the expiry of an access token
 type TokenWrapper struct {


### PR DESCRIPTION
During my usage of this zoho library, errors returned by zoho of type "invalid_client_secret" were not detected properly and this caused some issues to debug when it occurred. This PR supplies error handling pertaing to this error.

Reproduction:
To test this feature, while using zoho credentials, use ZOHO_CLIENT_ID  properly and provide a wrong key for ZOHO_CLIENT_SECRET. If using self-client, provide ZOHO_AUTH_CODE properly.